### PR TITLE
fix: allow installation on Zotero 9

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.*"
+      "strict_max_version": "9.*"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Zotero 9 has shipped, but the current `strict_max_version: "8.*"` in `addon/manifest.json` blocks installation on it.
- This one-line change bumps the cap to `"9.*"` so existing users on Zotero 9 can keep using the plugin.
- No source/runtime changes were required: I rebuilt the XPI with the existing code and verified it loads on Zotero 9 on macOS — the right-click "Get CCF Info" action, the CCF Info column, and the Citation Number column all continue to work.

## Test plan
- [x] `npm install && npm run build` succeeds (Node 22, macOS).
- [x] Install resulting XPI in Zotero 9 — plugin loads without compatibility error.
- [x] Right-click an item → "Get CCF Info" runs and populates the note.
- [x] "CCF Info" and "Citation Number" columns appear in the item tree and show data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fix #36 