### PR TITLE
ci: trigger v0.4.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - v**
   workflow_dispatch:


### PR DESCRIPTION
Temporarily trigger the existing Release workflow on the next push to `main` so `v0.4.0` can be published. The branch trigger will be removed immediately after the release succeeds.