### PR TITLE
ci: finish v0.4.0 release after tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,20 @@ jobs:
           version="v$(node -p "require('./package.json').version")"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$version"
-          git push origin "$version"
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "Tag $version already exists"
+          else
+            git tag "$version"
+            git push origin "$version"
+          fi
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    needs: create-tag
+    if: |
+      always() &&
+      ((github.ref == 'refs/heads/main' && needs.create-tag.result == 'success') ||
+       startsWith(github.ref, 'refs/tags/v') ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GitHub_TOKEN }}


### PR DESCRIPTION
Run the release job in the same one-shot workflow after ensuring the version tag exists. Tag creation is idempotent, so the already-created `v0.4.0` tag is reused.