### PR TITLE
ci: restore normal release triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v**
   workflow_dispatch:
@@ -14,34 +12,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  create-tag:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tag
-        run: |
-          version="v$(node -p "require('./package.json').version")"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git rev-parse "$version" >/dev/null 2>&1; then
-            echo "Tag $version already exists"
-          else
-            git tag "$version"
-            git push origin "$version"
-          fi
-
   release:
-    needs: create-tag
-    if: |
-      always() &&
-      ((github.ref == 'refs/heads/main' && needs.create-tag.result == 'success') ||
-       startsWith(github.ref, 'refs/tags/v') ||
-       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GitHub_TOKEN }}


### PR DESCRIPTION
Remove the one-shot `main` release trigger and tag helper now that `v0.4.0` has been published successfully. Restore the normal tag and manual workflow triggers.